### PR TITLE
Docs: add a missing new line in docs

### DIFF
--- a/docs/InterfaceActionsWML.md
+++ b/docs/InterfaceActionsWML.md
@@ -187,7 +187,8 @@ This tag shows a dialog box that can be used in place of the usual [message] wit
 **description:** a long description of the item. If it's too long, scrollbars will be automatically used. _This key supports Pango markup._
 
 **effect:** very short description of the item's effects. For example: `"This staff grants a melee 5-2 impact magical attack"`. _This key supports Pango markup._
-					**take_string:** required, this string will be displayed on the button that allows taking the item.
+
+**take_string:** required, this string will be displayed on the button that allows taking the item.
 
 **leave_string:** required, this string will be displayed on the button that allows refusing the item.
 


### PR DESCRIPTION
The **take_string** doc entry got jumbled into the effects entry due to a missing new line made it confusing to see for people with impaired sight. Thus, I added the new line and it looks okay now.

Closes #2 