### PR TITLE
Code cleanup type stuff

### DIFF
--- a/wlp_utils.lua
+++ b/wlp_utils.lua
@@ -1,16 +1,7 @@
 local utils = {}
 
 --! Function removes the first child with a given name.
---! melinath
-function utils.remove_child(cfg, name)
-	for index = 1, #cfg do
-		local value = cfg[index]
-		if value[1] == name then
-			table.remove(cfg, index)
-			return
-		end
-	end
-end
+utils.remove_child = wesnoth.deprecate_api('utils.remove_child', 'wml.remove_child', 1, nil, wml.remove_child)
 
 --! Function checks recursively if all values contained in table a are also contained in table b.
 --! melinath

--- a/wlp_utils.lua
+++ b/wlp_utils.lua
@@ -33,14 +33,14 @@ function utils.filter_wml( f, t, indent )
 
 			for key, value in pairs(f) do
 				if ( type(value) == "table" ) then
-					std_print( string.format( "%sEntering filter table: %s", indent, value[1] ) )
+					std_print( string.format( "%sEntering filter table: %s", indent, value.tag ) )
 
 					for index = 1, #t do
-						std_print( string.format( "%sChecking against: %s", indent, t[index][1] ) )
-						std_print( string.format( "%sName Match: %s", indent, tostring( value[1] == t[index][1] ) ) )
+						std_print( string.format( "%sChecking against: %s", indent, t[index].tag ) )
+						std_print( string.format( "%sName Match: %s", indent, tostring( value.tag == t[index].tag ) ) )
 
-						if( t[iindex][1] == value[1] ) then
-							local x=sub_filter( value[2], t[index][2] )
+						if( t[iindex].tag == value.tag ) then
+							local x=sub_filter( value.contents, t[index].contents )
 							std_print( string.format( "%sTable match: %s", indent, tostring(x) ) )
 
 							if x then return true end

--- a/wml-tags.lua
+++ b/wml-tags.lua
@@ -209,7 +209,7 @@ function wml_actions.nearest_hex(cfg)
 	end
 
 	if nearest_hex_found then
-		wml.variables[variable] = { x = nearest_hex_found[1], y = nearest_hex_found[2], terrain = wesnoth.current.map[{nearest_hex_found[1], nearest_hex_found[2]}] }
+		wml.variables[variable] = { x = nearest_hex_found[1], y = nearest_hex_found[2], terrain = wesnoth.current.map[nearest_hex_found] }
 	else wesnoth.interface.add_chat_message( "WML", "No suitable location found by [nearest_hex]" )
 	end
 end
@@ -243,7 +243,7 @@ function wesnoth.wml_actions.get_unit_defense(cfg)
 	local variable = cfg.variable or "defense"
 
 	for index, unit in ipairs(filter) do
-		local terrain = wesnoth.current.map[{unit.x, unit.y}]
+		local terrain = wesnoth.current.map[unit]
 		-- it is WML defense: the lower, the better. Converted to normal defense with 100 -
 		local defense = 100 - wesnoth.units.chance_to_be_hit ( unit, terrain )
 		wml.variables[string.format("%s[%d]", variable, index - 1)] = { id = unit.id, x = unit.x, y = unit.y, terrain = terrain, defense = defense }

--- a/wml-tags.lua
+++ b/wml-tags.lua
@@ -201,7 +201,7 @@ function wml_actions.nearest_hex(cfg)
 	local nearest_hex_found
 
 	for index,location in ipairs(wesnoth.map.find(filter)) do
-		local distance = wesnoth.map.distance_between( starting_x, starting_y, location[1], location[2] )
+		local distance = wesnoth.map.distance_between( starting_x, starting_y, location )
 		if distance < current_distance then
 			current_distance = distance
 			nearest_hex_found = location
@@ -375,7 +375,7 @@ function wml_actions.scatter_units(cfg) -- replacement for SCATTER_UNITS macro
 			local unit_to_put = unit_table
 			unit_to_put.type = unit_types[index2]
 
-			local free_x, free_y = wesnoth.paths.find_vacant_hex( where_to_place[1], where_to_place[2], unit_to_put)
+			local free_x, free_y = wesnoth.paths.find_vacant_hex( where_to_place, unit_to_put)
 			-- to avoid placing units in strange terrains, or overwriting, in case that the WML coder placed a wrong filter;
 			-- in such case, respect of scatter_radius is not guaranteed, exactly like in SCATTER_UNITS
 
@@ -387,7 +387,7 @@ function wml_actions.scatter_units(cfg) -- replacement for SCATTER_UNITS macro
 				-- and remove those that are too close
 				-- using standard ipairs jumps some locations
 				for index = #locations, 1, -1 do --lenght of locations, until 1, step -1
-					local distance = wesnoth.map.distance_between( where_to_place[1], where_to_place[2], locations[index][1], locations[index][2] )
+					local distance = wesnoth.map.distance_between( where_to_place, locations[index] )
 
 					if distance < scatter_radius then
 						table.remove( locations, index )


### PR DESCRIPTION
This is mostly changes according to conventions I apply to mainline Lua.

* Generally anything that accepts a location can be passed either a "location-like object" or two separate integers. A location-like object is any object that has either keys 1 and 2 or keys x and y. So, a unit is a location-like object.
* remove_child is available in the wml module, with identical behaviour
* When iterating through WML tags you can now address them as `v.tag`, `v.contents` rather than as `v[1]`, `v[2]`, which I think is easier to understand.

I only tested this minimally, which is to say I ran your test scenario repeatedly until I saw no errors.

You can feel free to just cherry-pick parts of this if you don't like some of the changes.